### PR TITLE
_includes/about: Add minor practical information

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -8,6 +8,21 @@
                 If you are interested in Research Software Engineering and want to connect with the community in the Nordics, you are warmly encouraged to join.
                 You can find instructions for submitting your contribution below. 
                 Registration will open soon (tickets will cost about 75€).
+
+		<br><br>
+
+		Expected schedule: <b>19 May:</b> suggested arrival in
+		the afternoon/evening to explore Gothenburg.  <b>20
+		May:</b> 9-17 main conference and lunch, dinner
+		after.  <b>21 May:</b> 9-17 main conference and lunch,
+		with afternoon possibly being more informal events.
+		Departures in the evening.
+
+		<br><br>
+
+		Gothenburg Airport (GOT) has flights from various
+		locations and is the typical arrival location.
+
             </p>
 
             <a class="btn btn-primary btn-lg" href="https://forms.gle/q6jtNJbBL26PyrGM8" target="_blank" rel="noreferrer noopener" role="button">Submit your abstract</a>


### PR DESCRIPTION
- This is in the about section but should be moved later
- We are adding this because it helps to contact some people
